### PR TITLE
several misc changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ matrix:
     - go: "1.8"
     - go: "1.9"
     - go: "1.10"
+      env: VET=1
     - go: tip
 
 script:
-  - make
+  - if [[ "$VET" = 1 ]]; then make; else make deps test; fi

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ errcheck:
 
 .PHONY: test
 test:
-	go test -cover -race ./
+	go test -cover -race ./...
 
 .PHONY: generate
 generate:
@@ -74,9 +74,9 @@ generate:
 
 .PHONY: testcover
 testcover:
-	@echo go test -race -covermode=atomic ./
+	@echo go test -race -covermode=atomic ./...
 	@echo "mode: atomic" > coverage.out
-	@for dir in $$(go list ./); do \
+	@for dir in $$(go list ./...); do \
 		go test -race -coverprofile profile.out -covermode=atomic $$dir ; \
 		if [ -f profile.out ]; then \
 			tail -n +2 profile.out >> coverage.out && rm profile.out ; \

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,15 @@ default: deps checkgofmt vet predeclared staticcheck unused ineffassign golint t
 
 .PHONY: deps
 deps:
-	go get -d -v -t ./
+	go get -d -v -t ./...
 
 .PHONY: updatedeps
 updatedeps:
-	go get -d -v -t -u -f ./
+	go get -d -v -t -u -f ./...
 
 .PHONY: install
 install:
-	go install ./
+	go install ./...
 
 .PHONY: checkgofmt
 checkgofmt:
@@ -27,20 +27,20 @@ checkgofmt:
 
 .PHONY: vet
 vet:
-	go vet ./
+	go vet ./...
 
 .PHONY: staticcheck
 staticcheck:
 	@if [ -n "$$(go version | awk '{ print $$3 }' | grep -v devel)" ]; then \
 		go get honnef.co/go/tools/cmd/staticcheck; \
-		echo staticcheck ./; \
-		staticcheck ./; \
+		echo staticcheck ./...; \
+		staticcheck ./...; \
 	fi
 
 .PHONY: unused
 unused:
 	@go get honnef.co/go/tools/cmd/unused
-	unused ./
+	unused ./...
 
 .PHONY: ineffassign
 ineffassign:
@@ -70,7 +70,7 @@ test:
 
 .PHONY: generate
 generate:
-	go generate ./
+	go generate ./...
 
 .PHONY: testcover
 testcover:

--- a/gopoet_test.go
+++ b/gopoet_test.go
@@ -2,6 +2,7 @@ package gopoet_test
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
 	"path/filepath"
 	"reflect"
@@ -18,6 +19,72 @@ var regenerate = false
 func TestSimpleEndToEnd(t *testing.T) {
 	// No comments, structs and interfaces created from TypeNames, just one file and package.
 
+	fooState := gopoet.NewTypeSpec("FooState", gopoet.Int64Type)
+	foo := gopoet.NewConst("FOO").Initialize("%s(%d)", fooState, 101)
+	bar := gopoet.NewConst("BAR").Initialize("%s(%d)", fooState, 202)
+	vfoo := gopoet.NewVar("vfoo").SetType(gopoet.StringType)
+	vmap := gopoet.NewVar("vmap").SetInitializer(gopoet.
+		Printlnf("map[string]%s{", fooState).
+		Printlnf("    %q: %s,", "foo", foo).
+		Printlnf("    %q: %s,", "bar", bar).
+		Println("}"))
+
+	fooDetails := gopoet.NewTypeSpec("FooDetails", gopoet.StructType(
+		gopoet.FieldType{Name: "ID", Type: gopoet.Int64Type, Tag: `json:"id"`},
+		gopoet.FieldType{Name: "Name", Type: gopoet.StringType, Tag: `json:"name"`},
+		gopoet.FieldType{Name: "Categories", Type: gopoet.SliceType(gopoet.StringType), Tag: `json:"categories"`},
+	))
+	fooInterface := gopoet.NewTypeSpec("IFoo", gopoet.InterfaceType(
+		[]gopoet.Symbol{gopoet.NewSymbol("fmt", "Stringer")},
+		gopoet.MethodType{Name: "DoIt", Signature: gopoet.Signature{
+			Args: []gopoet.ArgType{
+				{Type: gopoet.NamedType(gopoet.NewSymbol("net/http", "RoundTripper"))},
+				{Type: gopoet.BoolType},
+			},
+			Results: []gopoet.ArgType{{Type: gopoet.ErrorType}},
+		}},
+	))
+
+	file := gopoet.NewGoFile("basic.go", "foo.bar/baz", "baz").
+		AddType(fooState).
+		AddType(fooDetails).
+		AddType(fooInterface).
+		AddElement(gopoet.NewConstDecl(foo, bar)).
+		AddElement(gopoet.NewVarDecl(vfoo, vmap)).
+		AddElement(gopoet.NewFunc("MakeIt").
+			AddArg("foo", fooState.ToTypeName()).
+			AddArg("bar", gopoet.SliceType(gopoet.StringType)).
+			AddArg("baz", gopoet.FuncTypeVariadic([]gopoet.ArgType{
+				{Type: gopoet.ChannelType(gopoet.StructType(), reflect.BothDir)},
+				{Type: gopoet.SliceType(gopoet.BoolType)},
+			},
+				nil)).
+			AddResult("", gopoet.ErrorType).
+			Printlnf("if foo == %s {", foo).
+			Printlnf("    return %s(%s(bar, %s))", gopoet.NewSymbol("errors", "New"), gopoet.NewSymbol("strings", "Join"), vfoo).
+			Printlnf("}").
+			Printlnf("bools := make([]bool, len(bar))").
+			Printlnf("for i := range bar {").
+			Printlnf("    _, bools[i] = vmap[bar[i]]").
+			Printlnf("}").
+			Printlnf("ch := make(chan struct{}, 1024)").
+			Printlnf("baz(ch, bools...)").
+			Printlnf("return nil")).
+		AddElement(gopoet.NewMethod(gopoet.NewReceiverForType("s", fooState), "String").
+			AddResult("", gopoet.StringType).
+			Printlnf("return %q", "foo")).
+		AddElement(gopoet.NewMethod(gopoet.NewPointerReceiverForType("d", fooDetails), "String").
+			AddResult("", gopoet.StringType).
+			Printlnf("return d.Name"))
+
+	verifyOutput(t, file)
+}
+
+func TestMoreComplexEndToEnd(t *testing.T) {
+	// Comments on all elements. Structs and interfaces created via TypeSpecs (NewStructTypeSpec
+	// and NewInterfaceTypeSpec), multiple files and packages.
+
+	// TODO...
 	fooState := gopoet.NewTypeSpec("FooState", gopoet.Int64Type)
 	foo := gopoet.NewConst("FOO").Initialize("%s(%d)", fooState, 101)
 	bar := gopoet.NewConst("BAR").Initialize("%s(%d)", fooState, 202)
@@ -76,8 +143,12 @@ func TestSimpleEndToEnd(t *testing.T) {
 			AddResult("", gopoet.StringType).
 			Printlnf("return d.Name"))
 
+	verifyOutput(t, f1)
+}
+
+func verifyOutput(t *testing.T, files ...*gopoet.GoFile) {
 	if regenerate {
-		err := gopoet.WriteGoFilesToFileSystem("./test-outputs", f1)
+		err := gopoet.WriteGoFilesToFileSystem("./test-outputs", files...)
 		if err != nil {
 			if fe, ok := err.(*gopoet.FormatError); ok {
 				t.Errorf("unexpected formatter error: %v\n%s", err, string(fe.Unformatted))
@@ -88,8 +159,12 @@ func TestSimpleEndToEnd(t *testing.T) {
 		return
 	}
 
-	var buf bytes.Buffer
-	err := gopoet.WriteGoFile(&buf, f1)
+	outputs := map[string]*bytes.Buffer{}
+	err := gopoet.WriteGoFiles(func(path string) (io.WriteCloser, error) {
+		var buf bytes.Buffer
+		outputs[path] = &buf
+		return nopCloser{w: &buf}, nil
+	}, files...)
 	if err != nil {
 		if fe, ok := err.(*gopoet.FormatError); ok {
 			t.Fatalf("unexpected formatter error: %v\n%s", err, string(fe.Unformatted))
@@ -97,12 +172,26 @@ func TestSimpleEndToEnd(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	}
-	golden, err := ioutil.ReadFile(filepath.Join("./test-outputs", f1.Package().ImportPath, f1.Name))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	for path, buf := range outputs {
+		golden, err := ioutil.ReadFile(filepath.Join("./test-outputs", path))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		actual := buf.Bytes()
+		if !bytes.Equal(golden, actual) {
+			t.Errorf("wrong generated output!\nExpected:\n%s\nActual:\n%s", golden, actual)
+		}
 	}
-	actual := buf.Bytes()
-	if !bytes.Equal(golden, actual) {
-		t.Errorf("wrong generated output!\nExpected:\n%s\nActual:\n%s", golden, actual)
-	}
+}
+
+type nopCloser struct {
+	w io.Writer
+}
+
+func (c nopCloser) Write(p []byte) (n int, err error) {
+	return c.w.Write(p)
+}
+
+func (c nopCloser) Close() error {
+	return nil
 }


### PR DESCRIPTION
* change `WriteGoFiles` to use `io.WriteCloser`, not `io.Writer`
* add second test case (currently just copy of first case... will address later), refactor golden output validation to follow suit
* consistently use `MethodRef` as value type (e.g. no pointer)
* only run static checks in CI for Go 1.10
* make sure any sub-packages (in case any are added) are tested during CI