### PR TITLE
adds several new tests

### DIFF
--- a/gopoet_test.go
+++ b/gopoet_test.go
@@ -84,47 +84,67 @@ func TestMoreComplexEndToEnd(t *testing.T) {
 	// Comments on all elements. Structs and interfaces created via TypeSpecs (NewStructTypeSpec
 	// and NewInterfaceTypeSpec), multiple files and packages.
 
-	// TODO...
-	fooState := gopoet.NewTypeSpec("FooState", gopoet.Int64Type)
-	foo := gopoet.NewConst("FOO").Initialize("%s(%d)", fooState, 101)
-	bar := gopoet.NewConst("BAR").Initialize("%s(%d)", fooState, 202)
-	vfoo := gopoet.NewVar("vfoo").SetType(gopoet.StringType)
-	vmap := gopoet.NewVar("vmap").SetInitializer(gopoet.
-		Printlnf("map[string]%s{", fooState).
-		Printlnf("    %q: %s,", "foo", foo).
-		Printlnf("    %q: %s,", "bar", bar).
-		Println("}"))
+	/////////////////////////////////
+	// foo.bar.2/baz/basic.go
+	/////////////////////////////////
 
-	fooDetails := gopoet.NewTypeSpec("FooDetails", gopoet.StructType(
-		gopoet.FieldType{Name: "ID", Type: gopoet.Int64Type, Tag: `json:"id"`},
-		gopoet.FieldType{Name: "Name", Type: gopoet.StringType, Tag: `json:"name"`},
-		gopoet.FieldType{Name: "Categories", Type: gopoet.SliceType(gopoet.StringType), Tag: `json:"categories"`},
-	))
-	fooInterface := gopoet.NewTypeSpec("IFoo", gopoet.InterfaceType(
-		[]gopoet.Symbol{gopoet.NewSymbol("fmt", "Stringer")},
-		gopoet.MethodType{Name: "DoIt", Signature: gopoet.Signature{
-			Args: []gopoet.ArgType{
-				{Type: gopoet.NamedType(gopoet.NewSymbol("net/http", "RoundTripper"))},
-				{Type: gopoet.BoolType},
-			},
-			Results: []gopoet.ArgType{{Type: gopoet.ErrorType}},
-		}},
-	))
+	fooState := gopoet.NewTypeSpec("FooState", gopoet.Int64Type).
+		SetComment("FooState is the state of a foo")
+	foo := gopoet.NewConst("FOO").
+		SetComment("The state that is fooey.").
+		Initialize("%s(%d)", fooState, 101)
+	bar := gopoet.NewConst("BAR").
+		SetComment("The state that is barry.").
+		Initialize("%s(%d)", fooState, 202)
+	vfoo := gopoet.NewVar("vfoo").
+		SetType(gopoet.StringType).
+		SetComment("Global variable that holds a foo string.")
+	vmap := gopoet.NewVar("vmap").
+		SetComment("Variable that is a mapping of strings to foo states.").
+		SetInitializer(gopoet.
+			Printlnf("map[string]%s{", fooState).
+			Printlnf("    %q: %s,", "foo", foo).
+			Printlnf("    %q: %s,", "bar", bar).
+			Println("}"))
 
-	f1 := gopoet.NewGoFile("basic.go", "foo.bar/baz", "baz").
+	fooDetails := gopoet.NewStructTypeSpec("FooDetails",
+		gopoet.NewField("ID", gopoet.Int64Type).
+			SetTag(`json:"id"`).
+			SetComment("ID is a unique identifier for this foo"),
+		gopoet.NewField("Name", gopoet.StringType).
+			SetTag(`json:"name"`).
+			SetComment("Name is the display name for this foo"),
+		gopoet.NewField("Categories", gopoet.SliceType(gopoet.StringType)).
+			SetTag(`json:"categories"`).
+			SetComment("Categories is a slice of category names"),
+	).SetComment("FooDetails provide the gory details for your foo.")
+
+	fooInterface := gopoet.NewInterfaceTypeSpec("IFoo",
+		gopoet.NewInterfaceEmbed(gopoet.NewSymbol("fmt", "Stringer")).
+			SetComment("All IFoos can print to string."),
+		gopoet.NewInterfaceMethod("DoIt").
+			AddArg("", gopoet.NamedType(gopoet.NewSymbol("net/http", "RoundTripper"))).
+			AddArg("", gopoet.BoolType).
+			AddResult("", gopoet.ErrorType).
+			SetComment("DoIt massages the foo into producing one or more frobnitz."),
+	).SetComment("IFoo is for producing frobnitzes.")
+
+	f1 := gopoet.NewGoFile("basic.go", "foo.bar.2/baz", "baz").
 		AddType(fooState).
 		AddType(fooDetails).
 		AddType(fooInterface).
-		AddElement(gopoet.NewConstDecl(foo, bar)).
-		AddElement(gopoet.NewVarDecl(vfoo, vmap)).
+		AddElement(gopoet.NewConstDecl(foo, bar).
+			SetComment("some constants")).
+		AddElement(gopoet.NewVarDecl(vfoo, vmap).
+			SetComment("some variables")).
 		AddElement(gopoet.NewFunc("MakeIt").
+			SetComment("MakeIt does a bunch of silly things, possibly returning an error.").
 			AddArg("foo", fooState.ToTypeName()).
 			AddArg("bar", gopoet.SliceType(gopoet.StringType)).
 			AddArg("baz", gopoet.FuncTypeVariadic([]gopoet.ArgType{
 				{Type: gopoet.ChannelType(gopoet.StructType(), reflect.BothDir)},
 				{Type: gopoet.SliceType(gopoet.BoolType)},
-			},
-				nil)).
+			}, nil)).
 			AddResult("", gopoet.ErrorType).
 			Printlnf("if foo == %s {", foo).
 			Printlnf("    return %s(%s(bar, %s))", gopoet.NewSymbol("errors", "New"), gopoet.NewSymbol("strings", "Join"), vfoo).
@@ -137,11 +157,27 @@ func TestMoreComplexEndToEnd(t *testing.T) {
 			Printlnf("baz(ch, bools...)").
 			Printlnf("return nil")).
 		AddElement(gopoet.NewMethod(gopoet.NewReceiverForType("s", fooState), "String").
+			SetComment("String implements the fmt.Stringer interface").
 			AddResult("", gopoet.StringType).
 			Printlnf("return %q", "foo")).
 		AddElement(gopoet.NewMethod(gopoet.NewPointerReceiverForType("d", fooDetails), "String").
+			SetComment("String implements the fmt.Stringer interface").
 			AddResult("", gopoet.StringType).
 			Printlnf("return d.Name"))
+
+	// TODO: more packages and files
+
+	/////////////////////////////////
+	// foo.bar.2/fizz/foo.go
+	/////////////////////////////////
+
+	/////////////////////////////////
+	// foo.bar.2/fizz/bar.go
+	/////////////////////////////////
+
+	/////////////////////////////////
+	// foo.bar.2/buzz/main.go
+	/////////////////////////////////
 
 	verifyOutput(t, f1)
 }

--- a/imports.go
+++ b/imports.go
@@ -72,6 +72,7 @@ func (i *Imports) prefixForPackage(importPath, packageName string, registerIfNot
 	if packageName == "" {
 		p = path.Base(importPath)
 	}
+	pkgBase := p
 	suffix := 1
 	for {
 		if _, ok := i.pathsByName[p]; !ok {
@@ -86,7 +87,7 @@ func (i *Imports) prefixForPackage(importPath, packageName string, registerIfNot
 			}
 			return p + "."
 		}
-		p = fmt.Sprintf("%s%d", packageName, suffix)
+		p = fmt.Sprintf("%s%d", pkgBase, suffix)
 		suffix++
 	}
 }

--- a/imports_test.go
+++ b/imports_test.go
@@ -1,0 +1,120 @@
+package gopoet
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestImportPackages(t *testing.T) {
+	t.Run("RegisterImport", func(t *testing.T) {
+		doRegisterImport(t, (*Imports).RegisterImport)
+	})
+	t.Run("RegisterImportForPackage", func(t *testing.T) {
+		doRegisterImport(t, func(imp *Imports, pkgPath, name string) string {
+			return imp.RegisterImportForPackage(Package{Name: name, ImportPath: pkgPath})
+		})
+	})
+}
+
+func doRegisterImport(t *testing.T, fn func(imp *Imports, pkgPath, name string) string) {
+	checkPrefix := func(actual, expected string) {
+		if actual != expected {
+			t.Errorf("wrong import prefix: expected %q, got %q", expected, actual)
+		}
+	}
+
+	imp := NewImportsFor("foo.bar/baz")
+
+	// no conflict
+	p := fn(imp, "foo.bar/fizzbuzz", "fizzbuzz")
+	checkPrefix(p, "fizzbuzz.")
+	p = fn(imp, "foo.bar/fubar", "fubar")
+	checkPrefix(p, "fubar.")
+
+	// repeated register returns same prefix
+	p = fn(imp, "foo.bar/fizzbuzz", "fizzbuzz")
+	checkPrefix(p, "fizzbuzz.")
+	p = fn(imp, "foo.bar/fubar", "fubar")
+	checkPrefix(p, "fubar.")
+
+	// self import returns empty prefix
+	p = fn(imp, "foo.bar/baz", "baz")
+	checkPrefix(p, "")
+
+	// conflicts
+	p = fn(imp, "foo.bar.2/fubar", "fubar")
+	checkPrefix(p, "fubar1.")
+	p = fn(imp, "foo.bar.3/fubar", "fubar")
+	checkPrefix(p, "fubar2.")
+	p = fn(imp, "foo.bar.2/fizzbuzz", "fizzbuzz")
+	checkPrefix(p, "fizzbuzz1.")
+	p = fn(imp, "foo.bar.3/fizzbuzz", "fizzbuzz")
+	checkPrefix(p, "fizzbuzz2.")
+
+	// name doesn't match last path element
+	p = fn(imp, "foo.bar.4/fubar", "fubar_v4")
+	checkPrefix(p, "fubar_v4.")
+
+	// unknown name will use last path element and assume it's an alias
+	p = fn(imp, "foo.bar/fuzzywuzzy", "")
+	checkPrefix(p, "fuzzywuzzy.")
+	// one that conflicts
+	p = fn(imp, "foo.bar.5/fubar", "")
+	checkPrefix(p, "fubar3.")
+
+	// query via PrefixForPackage
+	p = imp.PrefixForPackage("foo.bar/fizzbuzz")
+	checkPrefix(p, "fizzbuzz.")
+	p = imp.PrefixForPackage("foo.bar/fubar")
+	checkPrefix(p, "fubar.")
+	p = imp.PrefixForPackage("foo.bar/baz")
+	checkPrefix(p, "")
+	p = imp.PrefixForPackage("foo.bar.2/fubar")
+	checkPrefix(p, "fubar1.")
+	p = imp.PrefixForPackage("foo.bar.3/fubar")
+	checkPrefix(p, "fubar2.")
+	p = imp.PrefixForPackage("foo.bar.2/fizzbuzz")
+	checkPrefix(p, "fizzbuzz1.")
+	p = imp.PrefixForPackage("foo.bar.3/fizzbuzz")
+	checkPrefix(p, "fizzbuzz2.")
+	p = imp.PrefixForPackage("foo.bar.4/fubar")
+	checkPrefix(p, "fubar_v4.")
+	p = imp.PrefixForPackage("foo.bar/fuzzywuzzy")
+	checkPrefix(p, "fuzzywuzzy.")
+	p = imp.PrefixForPackage("foo.bar.5/fubar")
+	checkPrefix(p, "fubar3.")
+	expectToPanic(t, func() {
+		imp.PrefixForPackage("something/never/imported")
+	})
+
+	// check which will use aliases in an import statement
+	// as well as that they are properly sorted
+	specs := imp.ImportSpecs()
+	expected := []ImportSpec{
+		{ImportPath: "foo.bar.2/fizzbuzz", PackageAlias: "fizzbuzz1"},
+		{ImportPath: "foo.bar.2/fubar", PackageAlias: "fubar1"},
+		{ImportPath: "foo.bar.3/fizzbuzz", PackageAlias: "fizzbuzz2"},
+		{ImportPath: "foo.bar.3/fubar", PackageAlias: "fubar2"},
+		{ImportPath: "foo.bar.4/fubar"},
+		{ImportPath: "foo.bar.5/fubar", PackageAlias: "fubar3"},
+		{ImportPath: "foo.bar/fizzbuzz"},
+		{ImportPath: "foo.bar/fubar"},
+		// alias since actual package name was unknown:
+		{ImportPath: "foo.bar/fuzzywuzzy", PackageAlias: "fuzzywuzzy"},
+	}
+	if !reflect.DeepEqual(specs, expected) {
+		t.Errorf("unexpected import specs\nExpected:\n%v\nActual:\n%v", expected, specs)
+	}
+}
+
+func expectToPanic(t *testing.T, fn func()) {
+	defer func() {
+		p := recover()
+		if p == nil {
+			t.Error("expected panic but nothing recovered")
+		}
+	}()
+	fn()
+}
+
+// TODO: tests for symbol and typename importing/re-writing

--- a/names.go
+++ b/names.go
@@ -35,6 +35,9 @@ func Export(s string) string {
 	if r == utf8.RuneError {
 		panic(fmt.Sprintf("%q is not valid UTF8", s))
 	}
+	if unicode.IsUpper(r) {
+		return s // already exported
+	}
 	upperR := unicode.ToUpper(r)
 	if upperR == r {
 		if r == '_' {

--- a/names_test.go
+++ b/names_test.go
@@ -1,0 +1,24 @@
+package gopoet
+
+import "testing"
+
+func TestExport(t *testing.T) {
+	checkName(t, Export, "foo", "Foo")
+	checkName(t, Export, "Foo", "Foo")
+	checkName(t, Export, "_foo", "Xfoo")
+	checkName(t, Export, "1foo", "X1foo")
+}
+
+func TestUnexport(t *testing.T) {
+	checkName(t, Unexport, "foo", "foo")
+	checkName(t, Unexport, "Foo", "foo")
+	checkName(t, Unexport, "_foo", "_foo")
+	checkName(t, Unexport, "1foo", "1foo")
+}
+
+func checkName(t *testing.T, fn func(string) string, input, output string) {
+	actual := fn(input)
+	if actual != output {
+		t.Errorf("%q: expected %q; got %q", input, output, actual)
+	}
+}

--- a/test-outputs/foo.bar.2/baz/basic.go
+++ b/test-outputs/foo.bar.2/baz/basic.go
@@ -1,0 +1,70 @@
+package baz
+
+import "errors"
+import "fmt"
+import "net/http"
+import "strings"
+
+// FooState is the state of a foo
+type FooState int64
+
+// FooDetails provide the gory details for your foo.
+type FooDetails struct {
+	// ID is a unique identifier for this foo
+	ID int64 `json:"id"`
+	// Name is the display name for this foo
+	Name string `json:"name"`
+	// Categories is a slice of category names
+	Categories []string `json:"categories"`
+}
+
+// IFoo is for producing frobnitzes.
+type IFoo interface {
+	// All IFoos can print to string.
+	fmt.Stringer
+	// DoIt massages the foo into producing one or more frobnitz.
+	DoIt(http.RoundTripper, bool) error
+}
+
+// some constants
+const (
+	// The state that is fooey.
+	FOO = FooState(101)
+	// The state that is barry.
+	BAR = FooState(202)
+)
+
+// some variables
+var (
+	// Global variable that holds a foo string.
+	vfoo string
+	// Variable that is a mapping of strings to foo states.
+	vmap = map[string]FooState{
+		"foo": FOO,
+		"bar": BAR,
+	}
+)
+
+// MakeIt does a bunch of silly things, possibly returning an error.
+func MakeIt(foo FooState, bar []string, baz func(chan struct{}, ...bool)) error {
+	if foo == FOO {
+		return errors.New(strings.Join(bar, vfoo))
+	}
+	bools := make([]bool, len(bar))
+	for i := range bar {
+		_, bools[i] = vmap[bar[i]]
+	}
+	ch := make(chan struct{}, 1024)
+	baz(ch, bools...)
+	return nil
+}
+
+// String implements the fmt.Stringer interface
+func (s FooState) String() string {
+	return "foo"
+}
+
+// String implements the fmt.Stringer interface
+func (d *FooDetails) String() string {
+	return d.Name
+}

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,267 @@
+package gopoet
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewType(t *testing.T) {
+	t.Run("KindNamed", func(t *testing.T) {
+		sym := Symbol{Package: NewPackage("foo/bar"), Name: "Baz"}
+		tn := NamedType(sym)
+		checkTypeName(t, tn, KindNamed, sym)
+
+		sym = Symbol{Package: NewPackage("unsafe"), Name: "Pointer"}
+		tn = UnsafePointerType
+		checkTypeName(t, tn, KindNamed, sym)
+		tn = BasicType(reflect.UnsafePointer) // special-case: this returns named type
+		checkTypeName(t, tn, KindNamed, sym)
+
+		sym = Symbol{Name: "error"}
+		tn = ErrorType
+		checkTypeName(t, tn, KindNamed, sym)
+	})
+
+	t.Run("KindBasic", func(t *testing.T) {
+		basicKinds := map[reflect.Kind]TypeName{
+			reflect.Int:        IntType,
+			reflect.Int8:       Int8Type,
+			reflect.Int16:      Int16Type,
+			reflect.Int32:      Int32Type,
+			reflect.Int64:      Int64Type,
+			reflect.Uint:       UintType,
+			reflect.Uint8:      Uint8Type,
+			reflect.Uint16:     Uint16Type,
+			reflect.Uint32:     Uint32Type,
+			reflect.Uint64:     Uint64Type,
+			reflect.Float32:    Float32Type,
+			reflect.Float64:    Float64Type,
+			reflect.Complex64:  Complex64Type,
+			reflect.Complex128: Complex128Type,
+			reflect.Bool:       BoolType,
+			reflect.String:     StringType,
+			reflect.Uintptr:    UintptrType,
+		}
+		for bk, tn := range basicKinds {
+			checkTypeName(t, tn, KindBasic, bk)
+			tn = BasicType(bk)
+			checkTypeName(t, tn, KindBasic, bk)
+		}
+	})
+
+	elems := []TypeName{BasicType(reflect.Int), ErrorType, UnsafePointerType, SliceType(BasicType(reflect.String))}
+
+	t.Run("KindSlice", func(t *testing.T) {
+		for _, e := range elems {
+			tn := SliceType(e)
+			checkTypeName(t, tn, KindSlice, e)
+		}
+	})
+
+	t.Run("KindPtr", func(t *testing.T) {
+		for _, e := range elems {
+			tn := PointerType(e)
+			checkTypeName(t, tn, KindPtr, e)
+		}
+	})
+
+	t.Run("KindArray", func(t *testing.T) {
+		for _, e := range elems {
+			for i := 1; i <= 10000; i *= 10 {
+				tn := ArrayType(e, int64(i))
+				checkTypeName(t, tn, KindArray, []interface{}{i, e})
+			}
+		}
+	})
+
+	t.Run("KindMap", func(t *testing.T) {
+		for _, k := range elems {
+			for _, e := range elems {
+				tn := MapType(k, e)
+				checkTypeName(t, tn, KindMap, []interface{}{k, e})
+			}
+		}
+	})
+
+	t.Run("KindChan", func(t *testing.T) {
+		for _, e := range elems {
+			for _, dir := range []reflect.ChanDir{reflect.SendDir, reflect.RecvDir, reflect.BothDir} {
+				tn := ChannelType(e, dir)
+				checkTypeName(t, tn, KindChan, []interface{}{dir, e})
+			}
+		}
+	})
+
+	t.Run("KindStruct", func(t *testing.T) {
+		tn := StructType()
+		checkTypeName(t, tn, KindStruct, []FieldType{})
+
+		fields := []FieldType{
+			{Name: "Foo", Type: IntType},
+			{Name: "bar", Type: StringType},
+			{Name: "baz", Type: SliceType(ByteType)},
+		}
+		tn = StructType(fields...)
+		checkTypeName(t, tn, KindStruct, fields)
+	})
+
+	t.Run("KindInterface", func(t *testing.T) {
+		tn := InterfaceType(nil)
+		checkTypeName(t, tn, KindInterface, []interface{}{[]MethodType{}, []Symbol{}})
+
+		methods := []MethodType{
+			{Name: "Foo", Signature: Signature{
+				Args: []ArgType{
+					{Name: "a", Type: IntType},
+					{Name: "b", Type: StringType},
+				},
+			}},
+			{Name: "Bar", Signature: Signature{
+				Results: []ArgType{{Type: ErrorType}},
+			}},
+		}
+		tn = InterfaceType(nil, methods...)
+		checkTypeName(t, tn, KindInterface, []interface{}{methods, []Symbol{}})
+
+		embeds := []Symbol{
+			{Name: "Stringer", Package: NewPackage("fmt")},
+			{Name: "Reader", Package: NewPackage("io")},
+		}
+		tn = InterfaceType(embeds)
+		checkTypeName(t, tn, KindInterface, []interface{}{[]MethodType{}, embeds})
+
+		tn = InterfaceType(embeds, methods...)
+		checkTypeName(t, tn, KindInterface, []interface{}{methods, embeds})
+	})
+
+	t.Run("KindFunc", func(t *testing.T) {
+		args := []ArgType{
+			{Name: "a", Type: IntType},
+			{Name: "b", Type: StringType},
+		}
+		rets := []ArgType{{Type: ErrorType}}
+		sig := &Signature{Args: args, Results: rets}
+
+		tn := FuncType(args, rets)
+		checkTypeName(t, tn, KindFunc, sig)
+
+		tn = FuncTypeFromSig(sig)
+		checkTypeName(t, tn, KindFunc, sig)
+
+		sig.IsVariadic = true
+		func() {
+			// variadic function not allowed if last argument is not a slice
+			defer func() {
+				p := recover()
+				if p == nil {
+					t.Error("expecting a panic due to bad signature but nothing recovered")
+				}
+			}()
+			FuncTypeVariadic(args, rets)
+		}()
+
+		args = append(args, ArgType{Type: SliceType(StringType)})
+		sig.Args = args
+
+		tn = FuncTypeVariadic(args, rets)
+		checkTypeName(t, tn, KindFunc, sig)
+	})
+}
+
+func TestTypeNameForGoType(t *testing.T) {
+	// TODO
+}
+
+func TestTypeNameForReflectType(t *testing.T) {
+	// TODO
+}
+
+func checkTypeName(t *testing.T, tn TypeName, expectedKind TypeKind, val interface{}) {
+	if tn.Kind() != expectedKind {
+		t.Errorf("TypeName has wrong kind: %v != %v", tn.Kind(), expectedKind)
+	}
+
+	var expectedSym Symbol
+	if expectedKind == KindNamed {
+		expectedSym = val.(Symbol)
+	}
+	if tn.Symbol() != expectedSym {
+		t.Errorf("Symbol() returned wrong value: %v != %v", tn.Symbol(), expectedSym)
+	}
+
+	var expectedBasicKind reflect.Kind
+	if expectedKind == KindBasic {
+		expectedBasicKind = val.(reflect.Kind)
+	} else {
+		expectedBasicKind = reflect.Invalid
+	}
+	if tn.BasicKind() != expectedBasicKind {
+		t.Errorf("BasicKind() returned wrong value: %v != %v", tn.BasicKind(), expectedBasicKind)
+	}
+
+	var expectedElem TypeName
+	if expectedKind == KindPtr || expectedKind == KindSlice {
+		expectedElem = val.(TypeName)
+	} else if expectedKind == KindArray || expectedKind == KindChan || expectedKind == KindMap {
+		expectedElem = val.([]interface{})[1].(TypeName)
+	}
+	if !reflect.DeepEqual(tn.Elem(), expectedElem) {
+		t.Errorf("Elem() returned wrong value: %v != %v", tn.Elem(), expectedElem)
+	}
+
+	var expectedLen int
+	if expectedKind == KindArray {
+		expectedLen = val.([]interface{})[0].(int)
+	} else {
+		expectedLen = -1
+	}
+	if tn.Len() != int64(expectedLen) {
+		t.Errorf("Len() returned wrong value: %v != %v", tn.Len(), expectedLen)
+	}
+
+	var expectedKey TypeName
+	if expectedKind == KindMap {
+		expectedKey = val.([]interface{})[0].(TypeName)
+	}
+	if tn.Key() != expectedKey {
+		t.Errorf("Key() returned wrong value: %v != %v", tn.Key(), expectedKey)
+	}
+
+	var expectedDir reflect.ChanDir
+	if expectedKind == KindChan {
+		expectedDir = val.([]interface{})[0].(reflect.ChanDir)
+	}
+	if tn.Dir() != expectedDir {
+		t.Errorf("Dir() returned wrong value: %v != %v", tn.Dir(), expectedDir)
+	}
+
+	var expectedSig *Signature
+	if expectedKind == KindFunc {
+		expectedSig = val.(*Signature)
+	}
+	if !reflect.DeepEqual(tn.Signature(), expectedSig) {
+		t.Errorf("Signature() returned wrong value: %v != %v", tn.Signature(), expectedSig)
+	}
+
+	var expectedFields []FieldType
+	if expectedKind == KindStruct {
+		expectedFields = val.([]FieldType)
+	}
+	if !reflect.DeepEqual(tn.Fields(), expectedFields) {
+		t.Errorf("Fields() returned wrong value: %v != %v", tn.Signature(), expectedFields)
+	}
+
+	var expectedMethods []MethodType
+	var expectedEmbeds []Symbol
+	if expectedKind == KindInterface {
+		v := val.([]interface{})
+		expectedMethods = v[0].([]MethodType)
+		expectedEmbeds = v[1].([]Symbol)
+	}
+	if !reflect.DeepEqual(tn.Methods(), expectedMethods) {
+		t.Errorf("Methods() returned wrong value: %v != %v", tn.Methods(), expectedMethods)
+	}
+	if !reflect.DeepEqual(tn.Embeds(), expectedEmbeds) {
+		t.Errorf("Embeds() returned wrong value: %v != %v", tn.Embeds(), expectedEmbeds)
+	}
+}


### PR DESCRIPTION
- adds more unit tests for type names, Export/Unexport functions, and imports
- starts to flesh out second end-to-end code-gen test
- new tests found three bugs (also fixed in this branch):
  1. Emission of comments on type/var/const declarations was buggy
  2. Export function did not correctly handle case where symbol was already exported
  3. Generation of package alias for unnamed packages whose base path conflicts with existing import resulted in invalid prefix