### PR TITLE
fix build: staticcheck no longer supports Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,18 @@ sudo: false
 
 matrix:
   include:
-    - go: "1.8"
     - go: "1.9"
     - go: "1.10"
-      env: VET=1
     - go: "1.11"
+      env:
+      - GO111MODULE=off
+      - VET=1
+    - go: "1.11"
+      env: GO111MODULE=on
+    - go: "1.12"
+      env: GO111MODULE=off
+    - go: "1.12"
+      env: GO111MODULE=on
     - go: tip
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: default
-default: deps checkgofmt vet predeclared staticcheck unused ineffassign golint test
+default: deps checkgofmt vet predeclared staticcheck ineffassign golint test
 
 .PHONY: deps
 deps:
@@ -36,11 +36,6 @@ staticcheck:
 		echo staticcheck ./...; \
 		staticcheck ./...; \
 	fi
-
-.PHONY: unused
-unused:
-	@go get honnef.co/go/tools/cmd/unused
-	unused ./...
 
 .PHONY: ineffassign
 ineffassign:

--- a/types.go
+++ b/types.go
@@ -503,6 +503,7 @@ func TypeNameForGoType(t types.Type) TypeName {
 	case *types.Interface:
 		embeds := make([]Symbol, t.NumEmbeddeds())
 		for i := 0; i < t.NumEmbeddeds(); i++ {
+			//lint:ignore SA1019 we still support Go 1.10 which does not have non-deprecated EmbeddedType
 			obj := t.Embedded(i).Obj()
 			embeds[i] = Symbol{
 				Name:    obj.Name(),


### PR DESCRIPTION
Also removes `unused`, which reports itself as deprecated and superseded by `staticcheck`. While we're in here, drops CI support for Go 1.8.