### PR TITLE
fixes to code gen, unsafe access of unexported template data

### DIFF
--- a/code.go
+++ b/code.go
@@ -138,12 +138,12 @@ func (l line) qualify(imports *Imports) {
 	for i := range l.args {
 		switch a := l.args[i].(type) {
 		case Package:
-			p := imports.RegisterImportForPackage(a)
+			p := imports.registerPackage(a)
 			if p != a.Name {
 				l.args[i] = Package{Name: p, ImportPath: a.ImportPath}
 			}
 		case *Package:
-			p := imports.RegisterImportForPackage(*a)
+			p := imports.registerPackage(*a)
 			if p != a.Name {
 				l.args[i] = Package{Name: p, ImportPath: a.ImportPath}
 			}
@@ -209,7 +209,7 @@ func (l line) qualify(imports *Imports) {
 			}
 		case *types.Package:
 			p := PackageForGoType(a)
-			l.args[i] = imports.RegisterImportForPackage(p)
+			l.args[i] = imports.registerPackage(p)
 		}
 	}
 }

--- a/imports.go
+++ b/imports.go
@@ -39,6 +39,17 @@ func (i *Imports) RegisterImportForPackage(pkg Package) string {
 	return i.RegisterImport(pkg.ImportPath, pkg.Name)
 }
 
+// registerPackage is like RegisterImportForPackage, but instead of returning
+// the prefix (which includes a trailing dot if non-empty), it just returns the
+// package alias.
+func (i *Imports) registerPackage(pkg Package) string {
+	p := i.RegisterImportForPackage(pkg)
+	if len(p) > 0 && p[len(p)-1] == '.' {
+		p = p[:len(p)-1]
+	}
+	return p
+}
+
 // RegisterImport "imports" the specified package and returns the package prefix
 // to use for symbols in the imported package. It is safe to import the same
 // package repeatedly -- the same prefix will be returned every time. If an

--- a/templates_no_unsafe.go
+++ b/templates_no_unsafe.go
@@ -1,0 +1,15 @@
+//+build appengine gopherjs purego
+// NB: other environments where unsafe is unappropriate should use "purego" build tag
+// https://github.com/golang/go/issues/23172
+
+package gopoet
+
+import (
+	"reflect"
+)
+
+func getField(v reflect.Value, index int) (reflect.Value, bool) {
+	fld := v.Field(index)
+	// We can't use unsafe, so return false for unexported fields :(
+	return fld, !fld.IsValid() || fld.CanInterface()
+}

--- a/templates_unsafe.go
+++ b/templates_unsafe.go
@@ -1,0 +1,25 @@
+//+build !appengine,!gopherjs,!purego
+// NB: other environments where unsafe is unappropriate should use "purego" build tag
+// https://github.com/golang/go/issues/23172
+
+package gopoet
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+func getField(v reflect.Value, index int) (reflect.Value, bool) {
+	fld := v.Field(index)
+	if !fld.IsValid() || fld.CanInterface() {
+		return fld, true
+	}
+
+	// NB: We are being super-sneaky. Go reflection will not let us call
+	// fld.Interface() if fld was obtained via unexported fields (which it
+	// was!). So we use unsafe to create an alternate reflect.Value instance
+	// that represents the same value (same type and address). We can then
+	// call Interface() on *that*.
+	val := reflect.NewAt(fld.Type(), unsafe.Pointer(fld.UnsafeAddr())).Elem()
+	return val, true
+}


### PR DESCRIPTION
Two bugs are fixed with this:
* While qualifying data for a template, if the logic recursed into unexported struct fields, it would panic. This is because the code uses `Interface()` to examine and re-write values, but that it not allowed for `reflect.Value` instances accessed via an unexported field.

    This fixes that in two ways: (1) optionally use `unsafe` to create a `reflect.Value` instance on which `Interface()` *can* be called; (2) for environments where `unsafe` is disallowed, just do not attempt to qualify unexported fields.

* When rendering packages to a template or in a `CodeBlock` (via `Print*` methods), an extra trailing period (`.`) was added, causing the resulting code to be invalid/uncompilable. This was due to incorrect usage of the `RegisterImport*` method, which returns a _prefix_ (with trailing dot if the prefix is not empty), though several call sites expected it to instead return the new name (no trailing dot).